### PR TITLE
gmail: Use Label Get() in order to get better progress estimate.

### DIFF
--- a/lib/gmail/service.go
+++ b/lib/gmail/service.go
@@ -17,6 +17,7 @@ type gmailService interface {
 	GetRawMessage(id string) (string, error)
 	GetMetadata(id string) (*gmail.Message, error)
 	GetLabels() (*gmail.ListLabelsResponse, error)
+	GetLabel(id string) (*gmail.Label, error)
 	GetHistory(historyIndex uint64, label, page string) (*gmail.ListHistoryResponse, error)
 	GetMessages(q, page string) (*gmail.ListMessagesResponse, error)
 }
@@ -74,6 +75,16 @@ func (s *restGmailService) GetLabels() (*gmail.ListLabelsResponse, error) {
 	var err error
 	err = s.limiter.DoWithBackoff(func() (error, bool) {
 		r, err = s.svc.Labels.List("me").Do()
+		return isRateLimited(err)
+	})
+	return r, err
+}
+
+func (s *restGmailService) GetLabel(id string) (*gmail.Label, error) {
+	var r *gmail.Label
+	var err error
+	err = s.limiter.DoWithBackoff(func() (error, bool) {
+		r, err = s.svc.Labels.Get("me", id).Do()
 		return isRateLimited(err)
 	})
 	return r, err

--- a/lib/progress.go
+++ b/lib/progress.go
@@ -2,6 +2,6 @@ package lib
 
 // Progress represents a simple "done xxx out of yyy"-style progress report.
 type Progress struct {
-	Current uint
-	Total   uint
+	Current int64
+	Total   int64
 }

--- a/main.go
+++ b/main.go
@@ -78,11 +78,14 @@ func main() {
 		}
 		progress := make(chan lib.Progress)
 		go func() {
+			// Given how the label mail counting work we are only able to render the progress
+			// relative to the total number of mail label processed.
+			// So we specify below that the progress is done against labels and not mails.
 			l := time.Time{}
 			for p := range progress {
 				if time.Since(l).Seconds() > progressUpdateFreqSecs {
 					l = time.Now()
-					fmt.Printf("\r%d / %d   %.2f%%  ", p.Current, p.Total, float32(p.Current)/float32(p.Total)*100)
+					fmt.Printf("\r%d / %d labels : %.2f%%  ", p.Current, p.Total, float32(p.Current)/float32(p.Total)*100)
 				}
 			}
 			fmt.Println()


### PR DESCRIPTION
The ResultSizeEstimate field is only an estimate.

This leads the backup progress computation to use a wrong total account of mails hence displaying bogus results for non small mailboxes.

This commit creates a method to be used to compute something nearing the mail count (the label count) in order to compute a better backup progress estimation.

This works by retrieving the Labels() then iterating on the resulting list and filtering only by the label names that make sense.

The two cases this patch implements are:

1 ) No label is to be used for filtering:

Then we take into account labels in the following set: { "DRAFT" , "INBOX", "SENT", "TRASH" }.

The rationale for this is that these labels fit 'real' mails contrary to the other labels.

Note that account of mail labelled "TRASH" must be substracted from the account computed above.

2 ) A label was specified in order to make a selective backup:

Then simply account the number of mails having this label.

Finally the messages sent to feed the progress display goroutine takes into account the relevant label count of each mails if we are into the 1) case.
Again relevant labels are in { "DRAFT" , "INBOX", "SENT", "TRASH" }.